### PR TITLE
Fixed WPF project by removing extra FSharp.Core reference

### DIFF
--- a/AdventTrees2016.sln
+++ b/AdventTrees2016.sln
@@ -7,6 +7,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "AdventTreesAvalonia", "Adve
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "TreeLogic", "TreeLogic\TreeLogic.fsproj", "{4F08950C-F0DD-4A1C-AD00-77DE9B179879}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "AdventTrees2016", "AdventTrees2016\AdventTrees2016.fsproj", "{8B16CE2B-C672-4775-AA4B-5E95960545FD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{4F08950C-F0DD-4A1C-AD00-77DE9B179879}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F08950C-F0DD-4A1C-AD00-77DE9B179879}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F08950C-F0DD-4A1C-AD00-77DE9B179879}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B16CE2B-C672-4775-AA4B-5E95960545FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B16CE2B-C672-4775-AA4B-5E95960545FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B16CE2B-C672-4775-AA4B-5E95960545FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B16CE2B-C672-4775-AA4B-5E95960545FD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AdventTrees2016/AdventTrees2016.fsproj
+++ b/AdventTrees2016/AdventTrees2016.fsproj
@@ -87,9 +87,6 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
-    <Reference Include="FSharp.Core, Version=4.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>True</Private>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -107,7 +104,7 @@
   <ItemGroup>
     <ProjectReference Include="..\TreeLogic\TreeLogic.fsproj">
       <Name>TreeLogic</Name>
-      <Project>{4f08950c-f0dd-4a1c-ad00-77de9b179879}</Project>
+      <Project>{5eb8d62c-94c7-431a-b572-ee40a3c93e0e}</Project>
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>

--- a/AdventTrees2016/App.config
+++ b/AdventTrees2016/App.config
@@ -7,7 +7,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.4.3.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
Found that the WPF version of the project had an extra FSharp.Core reference. Removing allows the WPF project to build and run.